### PR TITLE
docs: generate plugin examples dynamically

### DIFF
--- a/md_gen/package-lock.json
+++ b/md_gen/package-lock.json
@@ -10,6 +10,15 @@
       "integrity": "sha512-FAYBGwC+W6F9+huFIDtn43cpy7+SzG+atzRiTfdp3inUKL2hXnd4rG8hylJLIh4+hqrQy1P17kvJByE/z825hA==",
       "dev": true
     },
+    "@types/yaml": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@types/yaml/-/yaml-1.9.7.tgz",
+      "integrity": "sha512-8WMXRDD1D+wCohjfslHDgICd2JtMATZU8CkhH8LVJqcJs6dyYj5TGptzP8wApbmEullGBSsCEzzap73DQ1HJaA==",
+      "dev": true,
+      "requires": {
+        "yaml": "*"
+      }
+    },
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
@@ -122,6 +131,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+      "dev": true
     },
     "yn": {
       "version": "3.1.1",

--- a/md_gen/package.json
+++ b/md_gen/package.json
@@ -12,8 +12,10 @@
   "license": "ISC",
   "devDependencies": {
     "@types/node": "^14.0.1",
+    "@types/yaml": "^1.9.7",
     "ts-node": "^8.10.1",
-    "typescript": "^3.9.2"
+    "typescript": "^3.9.2",
+    "yaml": "^1.10.0"
   },
   "dependencies": {
     "handlebars": "^4.7.6",

--- a/md_gen/plugin_template.md
+++ b/md_gen/plugin_template.md
@@ -10,27 +10,20 @@ by {{ authors }}
 {{ docs }}
 {{/if}}
 {{#if hasArgs}}
+
 ### Arguments
 
 {{ argsTable }}
 {{/if}}
-### Example installation
+
+### Example installation with default arguments
 
 ```json
-{
-  "PLUGINS": {
-    "{{ name }}": {
-      "path": "./plugins/{{ name }}/main.js",
-      "args": {}
-    }
-  }
-}
+---
+{{{ exampleJSON }}}
 ```
 
 ```yaml
 ---
-PLUGINS:
-  "{{ name }}":
-    path: "./plugins/{{ name }}/main.js"
-    args: {}
+{{{ exampleYAML }}}
 ```

--- a/md_gen/util.ts
+++ b/md_gen/util.ts
@@ -1,0 +1,45 @@
+/**
+ * Sets a value for a path in an object
+ *
+ * @param object the object to set in
+ * @param path the path to the value to set
+ * @param value the value to set
+ */
+export function setIn(object: Record<string, any>, path: string, value: any) {
+  if (typeof object !== "object" || !object) {
+    throw new Error(`${JSON.stringify(object)} is not an object`);
+  }
+
+  const stack = path.split(".");
+  let name = stack.shift();
+  let currentObject = object;
+
+  // Go up to the before last path
+  while (name && stack.length) {
+    // Set an empty object if no value exists
+    if (!Object.hasOwnProperty.call(currentObject, name)) {
+      currentObject[name] = {};
+    } else if (
+      typeof currentObject[name] !== "object" ||
+      !currentObject[name]
+    ) {
+      throw new Error(
+        `${JSON.stringify(
+          currentObject
+        )} already has non object property "${name}": ${JSON.stringify(
+          currentObject[name]
+        )}. Cannot set nested value for ${JSON.stringify(path)}`
+      );
+    }
+
+    // Save the current value
+    currentObject = currentObject[name];
+
+    name = stack.shift();
+  }
+
+  // For the final name in the path, set the value
+  if (name) {
+    currentObject[name] = value;
+  }
+}

--- a/plugins/adultempire/README.md
+++ b/plugins/adultempire/README.md
@@ -3,19 +3,24 @@
 by boi123212321
 
 Scrape data from adultempire
+
 ### Arguments
 
 | Name | Type    | Required | Description                    |
 | ---- | ------- | -------- | ------------------------------ |
 | dry  | Boolean | false    | Whether to commit data changes |
+
 ### Example installation
 
 ```json
+---
 {
   "PLUGINS": {
     "adultempire": {
       "path": "./plugins/adultempire/main.js",
-      "args": {}
+      "args": {
+        "dry": false
+      }
     }
   }
 }
@@ -24,7 +29,9 @@ Scrape data from adultempire
 ```yaml
 ---
 PLUGINS:
-  "adultempire":
-    path: "./plugins/adultempire/main.js"
-    args: {}
+  adultempire:
+    path: ./plugins/adultempire/main.js
+    args:
+      dry: false
+
 ```

--- a/plugins/freeones/README.md
+++ b/plugins/freeones/README.md
@@ -3,21 +3,28 @@
 by boi123212321,john4valor
 
 Scrape data from freeones.xxx. Custom fields can only be named as follows (not case sensitive): Hair Color, Eye Color, Ethnicity, Height, Weight, Birthplace, Zodiac
+
 ### Arguments
 
 | Name        | Type          | Required | Description                                                                                                                                                   |
 | ----------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | dry         | Boolean       | false    | Whether to commit data changes                                                                                                                                |
 | blacklist   | Array&lt;String&gt; | false    | Array of data fields to omit (possible values: &#x27;zodiac&#x27;, &#x27;aliases&#x27;, &#x27;height&#x27;, &#x27;weight&#x27;, &#x27;avatar&#x27;, &#x27;bornOn&#x27;, &#x27;labels&#x27;, &#x27;hair color&#x27;, &#x27;eye color&#x27;, &#x27;ethnicity&#x27;) |
-| useImperial | String        | false    | Use imperial units for height and weight (possible values: &#x27;true&#x27;, &#x27;false&#x27;)                                                                                   |
+| useImperial | Boolean       | false    | Use imperial units for height and weight (possible values: &#x27;true&#x27;, &#x27;false&#x27;)                                                                                   |
+
 ### Example installation
 
 ```json
+---
 {
   "PLUGINS": {
     "freeones": {
       "path": "./plugins/freeones/main.js",
-      "args": {}
+      "args": {
+        "dry": false,
+        "blacklist": [],
+        "useImperial": false
+      }
     }
   }
 }
@@ -26,7 +33,11 @@ Scrape data from freeones.xxx. Custom fields can only be named as follows (not c
 ```yaml
 ---
 PLUGINS:
-  "freeones":
-    path: "./plugins/freeones/main.js"
-    args: {}
+  freeones:
+    path: ./plugins/freeones/main.js
+    args:
+      dry: false
+      blacklist: []
+      useImperial: false
+
 ```

--- a/plugins/freeones/info.json
+++ b/plugins/freeones/info.json
@@ -1,7 +1,7 @@
 {
   "name": "freeones",
   "version": "0.4.0",
-  "authors": ["boi123212321","john4valor"],
+  "authors": ["boi123212321", "john4valor"],
   "description": "Scrape data from freeones.xxx. Custom fields can only be named as follows (not case sensitive): Hair Color, Eye Color, Ethnicity, Height, Weight, Birthplace, Zodiac",
   "arguments": [
     {
@@ -18,11 +18,11 @@
       "default": [],
       "description": "Array of data fields to omit (possible values: 'zodiac', 'aliases', 'height', 'weight', 'avatar', 'bornOn', 'labels', 'hair color', 'eye color', 'ethnicity')"
     },
-	{
+    {
       "name": "useImperial",
-      "type": "String",
+      "type": "Boolean",
       "required": false,
-      "default": [],
+      "default": false,
       "description": "Use imperial units for height and weight (possible values: 'true', 'false')"
     }
   ]

--- a/plugins/label_filter/README.md
+++ b/plugins/label_filter/README.md
@@ -3,20 +3,26 @@
 by boi123212321
 
 Filter labels returned by other plugins
+
 ### Arguments
 
 | Name      | Type          | Required | Description       |
 | --------- | ------------- | -------- | ----------------- |
 | whitelist | Array&lt;String&gt; | false    | Labels to include |
 | blacklist | Array&lt;String&gt; | false    | Labels to exclude |
+
 ### Example installation
 
 ```json
+---
 {
   "PLUGINS": {
     "label_filter": {
       "path": "./plugins/label_filter/main.js",
-      "args": {}
+      "args": {
+        "whitelist": [],
+        "blacklist": []
+      }
     }
   }
 }
@@ -25,7 +31,10 @@ Filter labels returned by other plugins
 ```yaml
 ---
 PLUGINS:
-  "label_filter":
-    path: "./plugins/label_filter/main.js"
-    args: {}
+  label_filter:
+    path: ./plugins/label_filter/main.js
+    args:
+      whitelist: []
+      blacklist: []
+
 ```

--- a/plugins/label_filter/info.json
+++ b/plugins/label_filter/info.json
@@ -8,13 +8,14 @@
       "name": "whitelist",
       "type": "Array<String>",
       "required": false,
+      "default": [],
       "description": "Labels to include"
     },
     {
       "name": "blacklist",
       "type": "Array<String>",
       "required": false,
-      "default": "thumbnail",
+      "default": [],
       "description": "Labels to exclude"
     }
   ]

--- a/plugins/profile_pics/README.md
+++ b/plugins/profile_pics/README.md
@@ -3,6 +3,7 @@
 by boi123212321,john4valor
 
 Find actor images based on local files. GIF support.
+
 ### Arguments
 
 | Name        | Type   | Required | Description                              |
@@ -11,14 +12,21 @@ Find actor images based on local files. GIF support.
 | path_alt    | String | true     | Folder to search alt thumbnail images in |
 | path_avatar | String | true     | Folder to search avatar images in        |
 | path_hero   | String | true     | Folder to search hero images in          |
+
 ### Example installation
 
 ```json
+---
 {
   "PLUGINS": {
     "profile_pics": {
       "path": "./plugins/profile_pics/main.js",
-      "args": {}
+      "args": {
+        "path_thumb": null,
+        "path_alt": null,
+        "path_avatar": null,
+        "path_hero": null
+      }
     }
   }
 }
@@ -27,7 +35,12 @@ Find actor images based on local files. GIF support.
 ```yaml
 ---
 PLUGINS:
-  "profile_pics":
-    path: "./plugins/profile_pics/main.js"
-    args: {}
+  profile_pics:
+    path: ./plugins/profile_pics/main.js
+    args:
+      path_thumb: null
+      path_alt: null
+      path_avatar: null
+      path_hero: null
+
 ```


### PR DESCRIPTION
- The examples in `plugin_template.md` are now entirely generated by `md_gen/index.ts` instead of being filled in. This ensures proper formatting with the relevant `stringify` functions, which will also handle nested objects easily.