### PR TITLE
Option to use discovered Avatar as Actor Thumbnail

### DIFF
--- a/plugins/freeones/README.md
+++ b/plugins/freeones/README.md
@@ -1,4 +1,4 @@
-## freeones 0.4.1
+## freeones 0.5.0
 
 by boi123212321, john4valor
 
@@ -6,13 +6,12 @@ Scrape data from freeones.xxx. Custom fields can only be named as follows (not c
 
 ### Arguments
 
-| Name        | Type          | Required | Description                                                                                                                                                   |
-| ----------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| dry         | Boolean       | false    | Whether to commit data changes                                                                                                                                |
-| blacklist   | Array&lt;String&gt; | false    | Array of data fields to omit (possible values: &#x27;zodiac&#x27;, &#x27;aliases&#x27;, &#x27;height&#x27;, &#x27;weight&#x27;, &#x27;avatar&#x27;, &#x27;bornOn&#x27;, &#x27;labels&#x27;, &#x27;hair color&#x27;, &#x27;eye color&#x27;, &#x27;ethnicity&#x27;) |
-| useImperial | Boolean       | false    | Use imperial units for height and weight (possible values: &#x27;true&#x27;, &#x27;false&#x27;)                                                                                   |
-| useAvatarAsThumbnail | Boolean       | false    | Use the discovered Actor Avatar as the Actor Thumbnail image (possible values: &#x27;true&#x27;, &#x27;false&#x27;)                                                                                   |
-
+| Name                 | Type          | Required | Description                                                                                                                                                   |
+| -------------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| dry                  | Boolean       | false    | Whether to commit data changes                                                                                                                                |
+| blacklist            | Array&lt;String&gt; | false    | Array of data fields to omit (possible values: &#x27;zodiac&#x27;, &#x27;aliases&#x27;, &#x27;height&#x27;, &#x27;weight&#x27;, &#x27;avatar&#x27;, &#x27;bornOn&#x27;, &#x27;labels&#x27;, &#x27;hair color&#x27;, &#x27;eye color&#x27;, &#x27;ethnicity&#x27;) |
+| useImperial          | Boolean       | false    | Use imperial units for height and weight                                                                                                                      |
+| useAvatarAsThumbnail | Boolean       | false    | Use the discovered Actor Avatar as the Actor Thumbnail image                                                                                                  |
 
 ### Example installation with default arguments
 
@@ -27,7 +26,7 @@ Scrape data from freeones.xxx. Custom fields can only be named as follows (not c
         "dry": false,
         "blacklist": [],
         "useImperial": false,
-        "useAvatarAsThumbnail": true
+        "useAvatarAsThumbnail": false
       }
     }
   },
@@ -53,6 +52,7 @@ PLUGINS:
       dry: false
       blacklist: []
       useImperial: false
+      useAvatarAsThumbnail: false
 PLUGIN_EVENTS:
   actorCreated:
     - freeones

--- a/plugins/freeones/README.md
+++ b/plugins/freeones/README.md
@@ -11,6 +11,8 @@ Scrape data from freeones.xxx. Custom fields can only be named as follows (not c
 | dry         | Boolean       | false    | Whether to commit data changes                                                                                                                                |
 | blacklist   | Array&lt;String&gt; | false    | Array of data fields to omit (possible values: &#x27;zodiac&#x27;, &#x27;aliases&#x27;, &#x27;height&#x27;, &#x27;weight&#x27;, &#x27;avatar&#x27;, &#x27;bornOn&#x27;, &#x27;labels&#x27;, &#x27;hair color&#x27;, &#x27;eye color&#x27;, &#x27;ethnicity&#x27;) |
 | useImperial | Boolean       | false    | Use imperial units for height and weight (possible values: &#x27;true&#x27;, &#x27;false&#x27;)                                                                                   |
+| useAvatarAsThumbnail | Boolean       | false    | Use the discovered Actor Avatar as the Actor Thumbnail image (possible values: &#x27;true&#x27;, &#x27;false&#x27;)                                                                                   |
+
 
 ### Example installation with default arguments
 
@@ -24,7 +26,8 @@ Scrape data from freeones.xxx. Custom fields can only be named as follows (not c
       "args": {
         "dry": false,
         "blacklist": [],
-        "useImperial": false
+        "useImperial": false,
+        "useAvatarAsThumbnail": true
       }
     }
   },

--- a/plugins/freeones/info.json
+++ b/plugins/freeones/info.json
@@ -25,6 +25,13 @@
       "required": false,
       "default": false,
       "description": "Use imperial units for height and weight (possible values: 'true', 'false')"
+    },
+    {
+      "name": "useAvatarAsThumbnail",
+      "type": "Boolean",
+      "required": false,
+      "default": false,
+      "description": "Use the discovered Actor Avatar as the Actor Thumbnail image (possible values: 'true', 'false')"
     }
   ]
 }

--- a/plugins/freeones/info.json
+++ b/plugins/freeones/info.json
@@ -1,6 +1,6 @@
 {
   "name": "freeones",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "authors": ["boi123212321", "john4valor"],
   "description": "Scrape data from freeones.xxx. Custom fields can only be named as follows (not case sensitive): Hair Color, Eye Color, Ethnicity, Height, Weight, Birthplace, Zodiac",
   "pluginEvents": ["actorCreated", "actorCustom"],
@@ -24,14 +24,14 @@
       "type": "Boolean",
       "required": false,
       "default": false,
-      "description": "Use imperial units for height and weight (possible values: 'true', 'false')"
+      "description": "Use imperial units for height and weight"
     },
     {
       "name": "useAvatarAsThumbnail",
       "type": "Boolean",
       "required": false,
       "default": false,
-      "description": "Use the discovered Actor Avatar as the Actor Thumbnail image (possible values: 'true', 'false')"
+      "description": "Use the discovered Actor Avatar as the Actor Thumbnail image"
     }
   ]
 }

--- a/plugins/freeones/main.js
+++ b/plugins/freeones/main.js
@@ -189,12 +189,12 @@ module.exports = async (ctx) => {
     const url = $(imgEl).attr("src");
     const imgId = await $createImage(url, `${actorName} (avatar)`);
 
-    if(!useAvatarAsThumbnail) {
+    if (!useAvatarAsThumbnail) {
       return { avatar: imgId };
     } else {
-      return { 
+      return {
         avatar: imgId,
-        thumbnail: imgId
+        thumbnail: imgId,
       };
     }
   }

--- a/plugins/freeones/main.js
+++ b/plugins/freeones/main.js
@@ -51,6 +51,14 @@ module.exports = async (ctx) => {
     $log("Imperial preference indicated. Using imperial values...");
   }
 
+  // Check Use Avatar as Thumbnail preference
+  const useAvatarAsThumbnail = args.useAvatarAsThumbnail;
+  if (!useAvatarAsThumbnail) {
+    $log("Will not use the Avatar as the Actor Thumbnail...");
+  } else {
+    $log("Will use the Avatar as the Actor Thumbnail...");
+  }
+
   let firstResult;
   try {
     firstResult = await getFirstSearchResult(ctx, actorName);
@@ -181,7 +189,14 @@ module.exports = async (ctx) => {
     const url = $(imgEl).attr("src");
     const imgId = await $createImage(url, `${actorName} (avatar)`);
 
-    return { avatar: imgId };
+    if(!useAvatarAsThumbnail) {
+      return { avatar: imgId };
+    } else {
+      return { 
+        avatar: imgId,
+        thumbnail: imgId
+      };
+    }
   }
 
   function getAge() {

--- a/plugins/freeones/test/whitney.spec.js
+++ b/plugins/freeones/test/whitney.spec.js
@@ -34,6 +34,31 @@ describe("freeones", () => {
     expect(result.nationality).to.equal("US");
     expect(result.bornOn).to.be.a("number");
     expect(result.avatar).to.be.a("string");
+    expect(result.thumbnail).to.be.undefined;
+    expect(result.labels).to.have.length.greaterThan(0);
+    expect(result.labels).to.contain("Brown Hair");
+    expect(result.labels).to.contain("Hazel Eyes");
+    expect(result.labels).to.contain("Caucasian");
+  });
+
+  it("Search 'Whitney Wright'", async () => {
+    console.log("Fetching freeones.xxx...");
+    const result = await searchWhitney({
+      useAvatarAsThumbnail: true,
+    });
+    expect(result.custom).to.deep.equal({
+      "hair color": "Brown",
+      "eye color": "Hazel",
+      ethnicity: "Caucasian",
+      height: 168,
+      weight: 57,
+      birthplace: "Oklahoma City, OK",
+      zodiac: "Virgo",
+    });
+    expect(result.nationality).to.equal("US");
+    expect(result.bornOn).to.be.a("number");
+    expect(result.avatar).to.be.a("string");
+    expect(result.thumbnail).to.equal(result.avatar);
     expect(result.labels).to.have.length.greaterThan(0);
     expect(result.labels).to.contain("Brown Hair");
     expect(result.labels).to.contain("Hazel Eyes");
@@ -55,6 +80,7 @@ describe("freeones", () => {
     expect(result.nationality).to.equal("US");
     expect(result.bornOn).to.be.a("number");
     expect(result.avatar).to.be.a("string");
+    expect(result.thumbnail).to.be.undefined;
     expect(result.labels).to.have.length.greaterThan(0);
     expect(result.labels).to.contain("Brown Hair");
     expect(result.labels).to.contain("Hazel Eyes");
@@ -77,6 +103,7 @@ describe("freeones", () => {
     expect(result.nationality).to.equal("US");
     expect(result.bornOn).to.be.a("number");
     expect(result.avatar).to.be.a("string");
+    expect(result.thumbnail).to.be.undefined;
     expect(result.labels).to.have.length.greaterThan(0);
     expect(result.labels).to.contain("Hazel Eyes");
     expect(result.labels).to.contain("Caucasian");
@@ -98,6 +125,7 @@ describe("freeones", () => {
     expect(result.nationality).to.equal("US");
     expect(result.bornOn).to.be.a("number");
     expect(result.avatar).to.be.a("string");
+    expect(result.thumbnail).to.be.undefined;
     expect(result.labels).to.have.length.greaterThan(0);
     expect(result.labels).to.contain("Brown Hair");
     expect(result.labels).to.contain("Caucasian");
@@ -119,6 +147,7 @@ describe("freeones", () => {
     expect(result.nationality).to.equal("US");
     expect(result.bornOn).to.be.a("number");
     expect(result.avatar).to.be.a("string");
+    expect(result.thumbnail).to.be.undefined;
     expect(result.labels).to.have.length.greaterThan(0);
     expect(result.labels).to.contain("Brown Hair");
     expect(result.labels).to.contain("Hazel Eyes");
@@ -140,6 +169,7 @@ describe("freeones", () => {
     expect(result.nationality).to.equal("US");
     expect(result.bornOn).to.be.a("number");
     expect(result.avatar).to.be.a("string");
+    expect(result.thumbnail).to.be.undefined;
     expect(result.labels).to.have.length.greaterThan(0);
     expect(result.labels).to.contain("Brown Hair");
     expect(result.labels).to.contain("Hazel Eyes");
@@ -162,6 +192,7 @@ describe("freeones", () => {
     expect(result.nationality).to.equal("US");
     expect(result.bornOn).to.be.a("number");
     expect(result.avatar).to.be.a("string");
+    expect(result.thumbnail).to.be.undefined;
     expect(result.labels).to.have.length.greaterThan(0);
     expect(result.labels).to.contain("Brown Hair");
     expect(result.labels).to.contain("Hazel Eyes");
@@ -185,6 +216,7 @@ describe("freeones", () => {
     expect(result.nationality).to.equal("US");
     expect(result.bornOn).to.be.a("number");
     expect(result.avatar).to.be.undefined;
+    expect(result.thumbnail).to.be.undefined;
     expect(result.labels).to.have.length.greaterThan(0);
     expect(result.labels).to.contain("Brown Hair");
     expect(result.labels).to.contain("Hazel Eyes");
@@ -208,6 +240,7 @@ describe("freeones", () => {
     expect(result.nationality).to.equal("US");
     expect(result.bornOn).to.be.a("number");
     expect(result.avatar).to.be.a("string");
+    expect(result.thumbnail).to.be.undefined;
     expect(result.labels).to.be.undefined;
   });
 
@@ -228,6 +261,7 @@ describe("freeones", () => {
     expect(result.nationality).to.be.undefined;
     expect(result.bornOn).to.be.a("number");
     expect(result.avatar).to.be.a("string");
+    expect(result.thumbnail).to.be.undefined;
     expect(result.labels).to.have.length.greaterThan(0);
     expect(result.labels).to.contain("Brown Hair");
     expect(result.labels).to.contain("Hazel Eyes");
@@ -251,6 +285,7 @@ describe("freeones", () => {
     expect(result.nationality).to.equal("US");
     expect(result.bornOn).to.be.a("number");
     expect(result.avatar).to.be.a("string");
+    expect(result.thumbnail).to.be.undefined;
     expect(result.labels).to.have.length.greaterThan(0);
     expect(result.labels).to.contain("Brown Hair");
     expect(result.labels).to.contain("Hazel Eyes");


### PR DESCRIPTION
New option has been added to Freeones plugin. 

Will automatically set the Actor Thumbnail to the same image as the Actor Avatar if the argument "useAvatarAsThumbnail" is set to True