### PR TITLE
chore(eslint): enfore camelcase

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,6 @@ module.exports = {
   },
   plugins: ["mocha", "chai-friendly"],
   rules: {
-    camcelcase: "off",
     "mocha/no-mocha-arrows": "off",
     // Disable the default rule
     "no-unused-expressions": 0,


### PR DESCRIPTION
All current files are actually compliant. I don't remember why I added it